### PR TITLE
refactor app config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,12 @@
 module.exports = {
   root: true,
-  extends: ["airbnb-typescript/base", "prettier"],
-  plugins: ["prettier"],
+  extends: [
+    "airbnb-typescript/base",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
+  plugins: ["prettier", "@typescript-eslint"],
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./tsconfig.json"
   },
@@ -17,6 +22,9 @@ module.exports = {
     ],
     "@typescript-eslint/no-floating-promises": ["error"],
     "@typescript-eslint/prefer-readonly": ["error"],
+
+    // already handled by global-require
+    "@typescript-eslint/no-var-requires": "off",
 
     "import/prefer-default-export": "off",
     "import/no-default-export": "warn",

--- a/README.md
+++ b/README.md
@@ -5,16 +5,17 @@
 What do you need?
 
 #### For POSIX
+
 - asdf - https://asdf-vm.com/#/core-manage-asdf-vm
 - asdf-nodejs - https://github.com/asdf-vm/asdf-nodejs
 - docker - https://www.docker.com/products/docker-desktop
 
 #### For Windows
+
 - Get WSL2 - https://docs.microsoft.com/en-us/windows/wsl/wsl2-install
-- Install asdf* into WSL2
+- Install asdf\* into WSL2
 - Clone repo into WSL2
 - For database use Docker for Windows with Linux containers.
-
 
 ```sh
 # Clone the repo
@@ -37,14 +38,14 @@ yarn --ignore-platform
 # use kitematic https://kitematic.com/
 
 # Create the configuration file. Change XXXX to the port on which your database is running.
-echo export DATABASE_URL='postgresql://postgres:mysecretpassword@localhost:XXXX/postgres' > .env
+export DATABASE_URL='postgresql://postgres:mysecretpassword@localhost:XXXX/postgres' > .env
 ```
 
 ### Development
 
 ```sh
-# Load the config
-source .env
+# Start a compiler, it will automatically recompile your code
+yarn watch
 
 # Run the application in development mode
 yarn dev

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yarn --ignore-platform
 # use kitematic https://kitematic.com/
 
 # Create the configuration file. Change XXXX to the port on which your database is running.
-export DATABASE_URL='postgresql://postgres:mysecretpassword@localhost:XXXX/postgres' > .env
+echo DATABASE_URL='postgresql://postgres:mysecretpassword@localhost:XXXX/postgres' > .env
 ```
 
 ### Development

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
   "scripts": {
     "start": "node build",
     "build": "tsc",
-    "dev": "tsc -w & DEVELOPMENT=true DATABASE_SYNC=true nodemon --watch 'build/**/*.js' --exec node --inspect build",
+    "watch": "tsc -w",
+    "dev": "DEVELOPMENT=true DATABASE_SYNC=true nodemon --watch 'build/**/*.js' --exec node --inspect build",
     "format": "prettier \"src/**/*.{js,jsx,ts,tsx}\" --write",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.7",
     "@types/hapi__hapi": "^19.0.2",
-    "@typescript-eslint/eslint-plugin": "^2.21.0",
+    "@typescript-eslint/eslint-plugin": "^2.24.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-typescript": "^7.0.0",
     "eslint-config-prettier": "^6.10.0",
@@ -33,6 +34,7 @@
     "@hapi/vision": "^6.0.0",
     "blipp": "^4.0.1",
     "class-transformer": "^0.2.3",
+    "dotenv": "^8.2.0",
     "hapi-swagger": "^12.1.1",
     "pg": "^7.18.2",
     "reflect-metadata": "^0.1.13",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 export const { DATABASE_URL } = process.env;
 
 export const HTTP_PORT = Number.parseInt(process.env.PORT ?? "3000", 10);

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,12 +423,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
   integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
 
-"@typescript-eslint/eslint-plugin@^2.21.0":
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.22.0.tgz#218ce6d4aa0244c6a40baba39ca1e021b26bb017"
-  integrity sha512-BvxRLaTDVQ3N+Qq8BivLiE9akQLAOUfxNHIEhedOcg8B2+jY8Rc4/D+iVprvuMX1AdezFYautuGDwr9QxqSxBQ==
+"@typescript-eslint/eslint-plugin@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz#a86cf618c965a462cddf3601f594544b134d6d68"
+  integrity sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.22.0"
+    "@typescript-eslint/experimental-utils" "2.24.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
@@ -441,6 +441,15 @@
   dependencies:
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/typescript-estree" "2.22.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/experimental-utils@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
+  integrity sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.24.0"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/parser@^2.19.0":
@@ -457,6 +466,19 @@
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz#a16ed45876abf743e1f5857e2f4a1c3199fd219e"
   integrity sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz#38bbc8bb479790d2f324797ffbcdb346d897c62a"
+  integrity sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -962,6 +984,11 @@ dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
 - adds additional linter rules
 - add `dotenv` package in order to automatically load config from `.env` during app start up
 - separates dev compilation and dev start into separate tasks because output was messy