### PR TITLE
add ratings and refactor api

### DIFF
--- a/src/helpers/group-by.ts
+++ b/src/helpers/group-by.ts
@@ -1,0 +1,22 @@
+export function groupBy<Elem, Key>(
+  array: readonly Elem[],
+  by: (elem: Elem) => Key
+): Map<Key, Elem[]> {
+  const map = new Map<Key, Elem[]>();
+
+  for (let i = 0; i < array.length; i += 1) {
+    const elem = array[i];
+    const key = by(elem);
+
+    const mappedGroup = map.get(key);
+    const group = mappedGroup === undefined ? [] : mappedGroup;
+
+    group.push(elem);
+
+    if (mappedGroup !== group) {
+      map.set(key, group);
+    }
+  }
+
+  return map;
+}

--- a/src/lib/comment/comments-service.ts
+++ b/src/lib/comment/comments-service.ts
@@ -7,13 +7,11 @@ function repo(): Repository<Comment> {
   return getRepository(Comment);
 }
 
-export async function listComments(incidentId: bigint): Promise<Comment[]> {
-  const comments = await repo().find({
+export function listComments(incidentId: bigint): Promise<Comment[]> {
+  return repo().find({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     incidentId: incidentId.toString() as any
   });
-  if (!comments) throw notFound("comment_not_found");
-  return comments;
 }
 
 export async function getComment(id: bigint): Promise<Comment> {

--- a/src/lib/customer/customer.ts
+++ b/src/lib/customer/customer.ts
@@ -2,6 +2,7 @@ import { PrimaryGeneratedColumn, Entity, Column, OneToMany } from "typeorm";
 import { Expose } from "class-transformer";
 import { Incident } from "../incident/incident";
 import { Comment } from "../comment/comment";
+import { IncidentRating } from "../incident/incident-rating";
 
 @Entity({ name: "customers" })
 export class Customer {
@@ -17,6 +18,12 @@ export class Customer {
     incident => incident.creator
   )
   incidents!: Incident[];
+
+  @OneToMany(
+    () => IncidentRating,
+    rating => rating.incident
+  )
+  ratings!: IncidentRating[];
 
   @OneToMany(
     () => Comment,

--- a/src/lib/incident/incident-rating.ts
+++ b/src/lib/incident/incident-rating.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryColumn,
+  CreateDateColumn,
+  JoinColumn,
+  ManyToOne,
+  Column,
+  Check
+} from "typeorm";
+import { Incident } from "./incident";
+import { Customer } from "../customer/customer";
+
+@Entity({ name: "incident_ratings" })
+export class IncidentRating {
+  @PrimaryColumn({ name: "incident_id", type: "bigint" })
+  incidentId!: bigint;
+
+  @PrimaryColumn({ name: "customer_id", type: "bigint" })
+  customerId!: bigint;
+
+  @JoinColumn({ name: "incident_id" })
+  @ManyToOne(
+    () => Incident,
+    incident => incident.ratings
+  )
+  incident!: Incident;
+
+  @JoinColumn({ name: "customer_id" })
+  @ManyToOne(
+    () => Customer,
+    customer => customer.ratings
+  )
+  customer!: Customer;
+
+  @Column({ type: "smallint" })
+  @Check("rating = -1 OR rating = 1")
+  rating!: -1 | 1;
+
+  @CreateDateColumn({ name: "created_at", type: "timestamp with time zone" })
+  createdAt!: Date;
+}

--- a/src/lib/incident/incident.ts
+++ b/src/lib/incident/incident.ts
@@ -16,6 +16,7 @@ import { GeoPoint } from "../geo-point/geo-point";
 import { Customer } from "../customer/customer";
 import { IncidentAffectedHeadsign } from "./incident-affected-headsign";
 import { Comment } from "../comment/comment";
+import { IncidentRating } from "./incident-rating";
 
 @Entity({ name: "incidents" })
 export class Incident {
@@ -31,6 +32,12 @@ export class Incident {
     customer => customer.incidents
   )
   creator!: Customer;
+
+  @OneToMany(
+    () => IncidentRating,
+    rating => rating.incident
+  )
+  ratings!: IncidentRating[];
 
   @OneToMany(
     () => Comment,

--- a/src/lib/incident/incidents-service.ts
+++ b/src/lib/incident/incidents-service.ts
@@ -171,7 +171,6 @@ export async function getIncidentRating(
       max(created_at) "lastRatedAt"
     FROM incident_ratings
     WHERE incident_id = $1
-    GROUP BY incident_id
   `,
     [incidentId.toString()]
   );

--- a/src/lib/incident/incidents-service.ts
+++ b/src/lib/incident/incidents-service.ts
@@ -1,23 +1,35 @@
-import { Repository, getRepository } from "typeorm";
+import { Repository, getRepository, getConnection } from "typeorm";
 import { notFound } from "@hapi/boom";
 import { Incident } from "./incident";
 import { transform } from "../../helpers/transform";
-import { queryHeadsignsOnThisTrack } from "../timetable/timetable-service";
+import {
+  queryHeadsignsOnThisTrack,
+  queryRouteType
+} from "../timetable/timetable-service";
+import { IncidentRating } from "./incident-rating";
+import { IncidentAffectedHeadsign } from "./incident-affected-headsign";
+import { groupBy } from "../../helpers/group-by";
+import { TimetableRouteType } from "../timetable/route-type";
 
 function repo(): Repository<Incident> {
   return getRepository(Incident);
+}
+
+function affectedHeadsignsRepo(): Repository<IncidentAffectedHeadsign> {
+  return getRepository(IncidentAffectedHeadsign);
+}
+
+function ratingsRepo(): Repository<IncidentRating> {
+  return getRepository(IncidentRating);
 }
 
 export function listIncidents(): Promise<Incident[]> {
   return repo().find();
 }
 
-export function listActiveIncidentsWithAffectedHeadsigns(): Promise<
-  Incident[]
-> {
+export function listActiveIncidents(): Promise<Incident[]> {
   return repo()
     .createQueryBuilder("incident")
-    .leftJoinAndSelect("incident.affectedHeadsigns", "affectedHeadsign")
     .where("now() - incident.created_at <= '1 hour'::interval")
     .getMany();
 }
@@ -28,17 +40,46 @@ export async function getIncident(id: bigint): Promise<Incident> {
   return incident;
 }
 
-export async function getIncidentWithAffectedHeadsigns(
-  id: bigint
-): Promise<Incident> {
-  const incident = await repo()
-    .createQueryBuilder("incident")
-    .leftJoinAndSelect("incident.affectedHeadsigns", "affectedHeadsign")
-    .where("incident.id = :id", { id: id.toString() })
-    .getOne();
+export async function getIncidentRouteType(
+  incidentId: bigint
+): Promise<TimetableRouteType | null> {
+  const res = await getConnection().query(
+    `
+    SELECT r.route_type "type"
+    FROM timetable_route r
+    JOIN incidents i ON r.route_id = i.route_id
+    WHERE i.id = $1
+  `,
+    [incidentId.toString()]
+  );
 
-  if (!incident) throw notFound("incident_not_found");
-  return incident;
+  return res[0] ? res[0].type : null;
+}
+
+export async function listIncidentAffectedHeadsignsWithGtfsType(
+  incidentId: BigInt
+): Promise<
+  { routeId: string; type: TimetableRouteType; headsigns: string[] }[]
+> {
+  const headsigns = await affectedHeadsignsRepo()
+    .createQueryBuilder()
+    .where("incident_id = :incidentId", { incidentId: incidentId.toString() })
+    .getMany();
+
+  const routesMap = groupBy(headsigns, headsign => headsign.routeId);
+
+  return (await queryRouteType(Array.from(routesMap.keys()))).map(
+    ({ routeId, type }) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const affectedHeadsigns = routesMap.get(routeId)!;
+
+      return {
+        routeId,
+        type,
+        headsigns: affectedHeadsigns.map(({ tripHeadsign }) => tripHeadsign)
+      };
+    }
+  );
 }
 
 export async function createIncident(
@@ -68,4 +109,76 @@ export async function createIncident(
   incident.creatorId = undefined as any;
 
   return incident;
+}
+
+export async function rateIncident(
+  incidentId: bigint,
+  customerId: bigint,
+  rating: -1 | 1
+): Promise<void> {
+  await getConnection()
+    .createQueryBuilder()
+    .insert()
+    .into(IncidentRating)
+    .values({
+      // those need to be casted because TypeORM crashes on bigint
+      incidentId: (incidentId.toString() as unknown) as bigint,
+      customerId: (customerId.toString() as unknown) as bigint,
+      rating
+    })
+    .onConflict(
+      "(incident_id, customer_id) DO UPDATE SET rating = EXCLUDED.rating"
+    )
+    .execute()
+    .catch(err => {
+      if (
+        err.constraint?.startsWith("FK_") &&
+        err.detail?.startsWith("Key (incident_id)=(")
+      ) {
+        throw notFound("incident");
+      }
+
+      throw err;
+    });
+}
+
+export async function deleteRating(
+  incidentId: bigint,
+  customerId: bigint
+): Promise<boolean> {
+  const { affected } = await ratingsRepo()
+    .createQueryBuilder()
+    .andWhere("incident_id = :incidentId", { incidentId })
+    .andWhere("customer_id = :customerId", { customerId })
+    .delete()
+    .execute();
+
+  return !!affected;
+}
+
+export async function getIncidentRating(
+  incidentId: bigint
+): Promise<{
+  positiveCount: number;
+  negativeCount: number;
+  lastRatedAt: Date;
+}> {
+  const res = await getConnection().query(
+    `
+    SELECT
+      count(*) FILTER ( WHERE rating = 1 ) "positiveCount",
+      count(*) FILTER ( WHERE rating = -1 ) "negativeCount",
+      max(created_at) "lastRatedAt"
+    FROM incident_ratings
+    WHERE incident_id = $1
+    GROUP BY incident_id
+  `,
+    [incidentId.toString()]
+  );
+
+  if (!res) {
+    throw notFound("incident");
+  }
+
+  return res;
 }

--- a/src/lib/timetable/timetable-service.ts
+++ b/src/lib/timetable/timetable-service.ts
@@ -4,6 +4,7 @@ import semaphoreFactory from "semaphore";
 import { notFound } from "@hapi/boom";
 import { getConnection } from "typeorm";
 import { GeoPoint } from "../geo-point/geo-point";
+import { TimetableRouteType } from "./route-type";
 
 // it's a timetable cache
 // it stores lazy parsed timetable files
@@ -211,9 +212,9 @@ export function queryHeadsignsOnThisTrack(
   );
 }
 
-function queryRouteType(
+export function queryRouteType(
   routeIds: string[]
-): Promise<{ routeId: string; type: number }[]> {
+): Promise<{ routeId: string; type: TimetableRouteType }[]> {
   return getConnection().query(
     `
     SELECT route_id "routeId",


### PR DESCRIPTION
## braking changes
`/incidents` and `/incidents/{id}` no longer returns `affectedHeadsigns`

## new staff
 - `/incidents/{id}/view` returns incident with `type`, `rating`, `comments`, `affectedHeadsigns`
 - ratings, just check out `/incidents/{id}/rating` in docs

## examples

### /incidents

![image](https://user-images.githubusercontent.com/12039839/83329865-13d3f300-a28c-11ea-8fcf-d0af47f23c8c.png)

### /incidents/{id}/view

![image](https://user-images.githubusercontent.com/12039839/83329888-3108c180-a28c-11ea-87d3-f29eaa4bcf8a.png)
